### PR TITLE
Hotfix/sendgrid email domain match

### DIFF
--- a/server/routes/helpers/emailHelpers.js
+++ b/server/routes/helpers/emailHelpers.js
@@ -14,12 +14,13 @@ var htmlBuilder = require('./emailBodyBuilder').buildBody
 sg.setApiKey(process.env.SENDGRID_KEY);
 
 const doNotSendEmails = process.env.DO_NOT_SEND_EMAILS && process.env.DO_NOT_SEND_EMAILS.toLowerCase() === 'true'
+const useTestDomain = (process.env.DEV_MODE && process.env.DEV_MODE.toLowerCase() === "true");
 
 const createPersonalization = (to, subject, html) => {
   return {
     to: to,
     from: {
-      email: 'no-reply@onefootin.com',
+      email: useTestDomain ?  'no-reply@test.onefootin.org' : 'no-reply@onefootin.org',
       name: 'One Foot In'
     },
     subject: subject,

--- a/server/routes/helpers/emailHelpers.js
+++ b/server/routes/helpers/emailHelpers.js
@@ -14,13 +14,12 @@ var htmlBuilder = require('./emailBodyBuilder').buildBody
 sg.setApiKey(process.env.SENDGRID_KEY);
 
 const doNotSendEmails = process.env.DO_NOT_SEND_EMAILS && process.env.DO_NOT_SEND_EMAILS.toLowerCase() === 'true'
-const useTestDomain = (process.env.DEV_MODE && process.env.DEV_MODE.toLowerCase() === "true");
 
 const createPersonalization = (to, subject, html) => {
   return {
     to: to,
     from: {
-      email: useTestDomain ?  'no-reply@test.onefootin.org' : 'no-reply@onefootin.org',
+      email: 'no-reply@onefootin.org',
       name: 'One Foot In'
     },
     subject: subject,


### PR DESCRIPTION
Emails must be sent from `.org` top-level-domain since this is the domain we own, and the domain that Sendgrid is now authenticated against